### PR TITLE
Added the node-fetch library to the wrapper to avoid a ReferenceError.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const soap = require('soap');
 const SoapCookie = require('soap-cookie');
+const fetch = require('node-fetch');
 
 class Client {
   constructor(options) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "soap": "^0.29.0",
     "soap-cookie": "^0.10.1",
-    "supports-color": "^7.1.0"
+    "supports-color": "^7.1.0",
+    "node-fetch": "^2.6.0"
   }
 }


### PR DESCRIPTION
When trying out the wrapper, I got the following error. So in order to avoid that, I added a reference to the node-fetch library.

`ReferenceError: fetch is not defined
    at new Client (C:\IT CONFIDENCE\IT-Confidence-Shell\node_modules\e-conomic-client\index.js:12:35)
    at Object.<anonymous> (C:\IT CONFIDENCE\IT-Confidence-Shell\src\/server.js:10:16)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Module._compile (C:\IT CONFIDENCE\IT-Confidence-Shell\node_modules\pirates\lib\index.js:99:24)
    at Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Object.newLoader [as .js] (C:\IT CONFIDENCE\IT-Confidence-Shell\node_modules\pirates\lib\index.js:104:7)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Function.Module._load (internal/modules/cjs/loader.js:727:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1047:10)
    at Object.<anonymous> (C:\IT CONFIDENCE\IT-Confidence-Shell\node_modules\@babel\node\lib\_babel-node.js:180:21)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Function.Module._load (internal/modules/cjs/loader.js:727:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1047:10)
    at internal/main/run_main_module.js:17:11`